### PR TITLE
added catboost categorical support & subset with optional tentative=True argument

### DIFF
--- a/src/BorutaShap.py
+++ b/src/BorutaShap.py
@@ -755,7 +755,7 @@ class BorutaShap:
         Returns the subset of desired features
         """
         if tentative:
-            return self.starting_X[self.accepted + self.tentative.tolist()]
+            return self.starting_X[self.accepted + self.tentative]
         else:
             return self.starting_X[self.accepted]
 


### PR DESCRIPTION
@Ekeany  I've been tinkering with Boruta-Shap and think I've got it figured out how to support categorical features. For me it's working with a catboostregressor.

- store categorical features as `self.X_categorical`
- when fitting, check if model is a catboost model and if so: pass argument to model 
`cat_features = self.X-categorical`
- when calling explain TreeExplainer, check if model is a catboost model and if so: pass `Pool(self.X_boruta, cat_features=self.X_categorical)`

And a small one:
- added optional keyword tentative to return also tentative features

Also this is my first ever pull request on someone else's repo so let me know if I'm doing thing wrong :)