### PR TITLE
fixed find_sample risk of infinite loop

### DIFF
--- a/src/BorutaShap.py
+++ b/src/BorutaShap.py
@@ -682,6 +682,8 @@ class BorutaShap:
             sample = np.take(self.preds, sample_indices)
             if ks_2samp(self.preds, sample).pvalue > 0.95:
                 break
+            
+            iteration+=1
 
             if iteration == 20:
                 element  += 1


### PR DESCRIPTION
What does this PR do?
=====================
It looks like the original `find_sample` does not increment `iteration` so there is a risk of an endless loop. 
I have added the line
`iteration+=1
`
References
==========

Testing performed
=================
No testing performed

Known issues
============
Apparently no issue has been raised yet, but it may happen 
