### PR TITLE
Allow dataframes for Y

### DIFF
--- a/src/BorutaShap.py
+++ b/src/BorutaShap.py
@@ -147,14 +147,14 @@ class BorutaShap:
 
         """
 
-        if isinstance(self.y, pd.Series):
+        if isinstance(self.y, pd.Series) or isinstance(self.y, pd.DataFrame):
             return self.y.isnull().any().any()
 
         elif isinstance(self.y, np.ndarray):
             return np.isnan(self.y).any()
 
         else:
-            raise AttributeError('Y must be a pandas Dataframe or a numpy array')
+            raise AttributeError('Y must be a pandas Dataframe, Series, or a numpy array')
 
 
     def check_missing_values(self):


### PR DESCRIPTION
Currently the error is incorrect, Y can only be a Pandas Series or an nd.array. 
Allow for dataframes, and series, and fix the Error message

What does this PR do?
=====================
Fixes a bug where Y can't be a dataframe, but the message says it can. Adds support for Y as a dataframe.
References
==========

Testing performed
=================

Known issues
============
