### PR TITLE
transform function for sklearn compatibility

### DIFF
--- a/src/BorutaShap.py
+++ b/src/BorutaShap.py
@@ -380,7 +380,9 @@ class BorutaShap:
         self.store_feature_importance()
         self.calculate_rejected_accepted_tentative(verbose=verbose)
 
-
+    def transform(self, X):
+        return self.Subset(self)
+        
     def calculate_rejected_accepted_tentative(self, verbose):
 
         """

--- a/src/BorutaShap.py
+++ b/src/BorutaShap.py
@@ -55,12 +55,106 @@ class BorutaShap:
 
         """
 
-        self.importance_measure = importance_measure.lower()
+        self.importance_measure = importance_measure
         self.percentile = percentile
         self.pvalue = pvalue
         self.classification = classification
         self.model = model
         self.check_model()
+
+    @classmethod
+    def _get_param_names(cls):
+        """Get parameter names for the estimator"""
+        # fetch the constructor or the original constructor before
+        # deprecation wrapping if any
+        init = getattr(cls.__init__, "deprecated_original", cls.__init__)
+        if init is object.__init__:
+            # No explicit constructor to introspect
+            return []
+
+        # introspect the constructor arguments to find the model parameters
+        # to represent
+        init_signature = inspect.signature(init)
+        # Consider the constructor parameters excluding 'self'
+        parameters = [
+            p
+            for p in init_signature.parameters.values()
+            if p.name != "self" and p.kind != p.VAR_KEYWORD
+        ]
+        for p in parameters:
+            if p.kind == p.VAR_POSITIONAL:
+                raise RuntimeError(
+                    "scikit-learn estimators should always "
+                    "specify their parameters in the signature"
+                    " of their __init__ (no varargs)."
+                    " %s with constructor %s doesn't "
+                    " follow this convention." % (cls, init_signature)
+                )
+        # Extract and sort argument names excluding 'self'
+        return sorted([p.name for p in parameters])
+
+    def get_params(self, deep=True):
+        """
+        Get parameters for this estimator.
+        Parameters
+        ----------
+        deep : bool, default=True
+            If True, will return the parameters for this estimator and
+            contained subobjects that are estimators.
+        Returns
+        -------
+        params : dict
+            Parameter names mapped to their values.
+        """
+        out = dict()
+        for key in self._get_param_names():
+            value = getattr(self, key)
+            if deep and hasattr(value, "get_params") and not isinstance(value, type):
+                deep_items = value.get_params().items()
+                out.update((key + "__" + k, val) for k, val in deep_items)
+            out[key] = value
+        return out
+
+    def set_params(self, **params):
+        """Set the parameters of this estimator.
+        The method works on simple estimators as well as on nested objects
+        (such as :class:`~sklearn.pipeline.Pipeline`). The latter have
+        parameters of the form ``<component>__<parameter>`` so that it's
+        possible to update each component of a nested object.
+        Parameters
+        ----------
+        **params : dict
+            Estimator parameters.
+        Returns
+        -------
+        self : estimator instance
+            Estimator instance.
+        """
+        if not params:
+            # Simple optimization to gain speed (inspect is slow)
+            return self
+        valid_params = self.get_params(deep=True)
+
+        nested_params = defaultdict(dict)  # grouped by prefix
+        for key, value in params.items():
+            key, delim, sub_key = key.partition("__")
+            if key not in valid_params:
+                local_valid_params = self._get_param_names()
+                raise ValueError(
+                    f"Invalid parameter {key!r} for estimator {self}. "
+                    f"Valid parameters are: {local_valid_params!r}."
+                )
+
+            if delim:
+                nested_params[key][sub_key] = value
+            else:
+                setattr(self, key, value)
+                valid_params[key] = value
+
+        for key, sub_params in nested_params.items():
+            valid_params[key].set_params(**sub_params)
+
+        return 
 
 
     def check_model(self):


### PR DESCRIPTION
What does this PR do?
=====================

for sklearn compatibility.
It enabled below.
```
from sklearn.pipeline import Pipeline
from sklearn.ensemble import RandomForestRegressor from BorutaShap import BorutaShap
from sklearn.model_selection import cross_val_predict

pipe = Pipeline(steps=[("selector", BorutaShap()), 
                　　　　　　　　　　　　　　("Regressor", RandomForestRegressor())])
pipe.fit(X,y)
 
```

Problem
=====================
cross_val_predict is not supported yet
```

~\Anaconda3\envs\lib\site-packages\sklearn\pipeline.py in _fit_transform_one(transformer, X, y, weight, message_clsname, message, **fit_params)
    891             res = transformer.fit_transform(X, y, **fit_params)
    892         else:
--> 893             res = transformer.fit(X, y, **fit_params).transform(X)
    894 
    895     if weight is None:

AttributeError: 'NoneType' object has no attribute 'transform'
```

The reason for this is that BorutaSHAP does not implement get_params and set_params, so clone(BorutaSHAP()) does not work.

