### PR TITLE
in response to [BUG] BorutaSHAP.py load Boston Import Error #111

### DIFF
--- a/src/BorutaShap.py
+++ b/src/BorutaShap.py
@@ -1,5 +1,5 @@
 from sklearn.ensemble import RandomForestClassifier, RandomForestRegressor, IsolationForest
-from sklearn.datasets import load_breast_cancer, load_boston
+from sklearn.datasets import load_breast_cancer, load_diabetes
 from statsmodels.stats.multitest import multipletests
 from sklearn.model_selection import train_test_split
 from sklearn.preprocessing import MinMaxScaler
@@ -1051,8 +1051,8 @@ def load_data(data_type='classification'):
         y = X.pop('target')
 
     elif data_type == 'regression':
-        boston = load_boston()
-        X = pd.DataFrame(np.c_[boston['data'], boston['target']], columns = np.append(boston['feature_names'], ['target']))
+        diabetes = load_diabetes()
+        X = pd.DataFrame(np.c_[diabetes['data'], diabetes['target']], columns = np.append(diabetes['feature_names'], ['target']))
         y = X.pop('target')
 
     else:


### PR DESCRIPTION
Scikit-learn >1.2 do not support the use of the Boston dataset from sklearn.datasets. This problem was raised back in december: https://github.com/Ekeany/Boruta-Shap/issues/111 and while one could make workaround importing Boston dataset from other sources, I am not an official maintainer. I merely suggest to replace sklearn.datasets toy dataset: load_boston() with load_diabetes().

What does this PR do?
=====================
This PR replaces the use of the load_boston() dataset in BorutaShap with load_diabetes() to avoid compatibility issues with scikit-learn >1.2.

References
==========
-Issue raised in December 2022: https://github.com/Ekeany/Boruta-Shap/issues/111
-Documentation for load_diabetes(): https://scikit-learn.org/stable/modules/generated/sklearn.datasets.load_diabetes.html#sklearn.datasets.load_diabetes

Testing performed
=================
I have tested the loading functionality, replacing load_diabetes() with load_boston(), on my local machine and the code runs without errors. 

Known issues
============