### PR TITLE
Fix tentative.to_list bug

### DIFF
--- a/src/BorutaShap.py
+++ b/src/BorutaShap.py
@@ -1012,7 +1012,7 @@ class BorutaShap:
         Returns the subset of desired features
         """
         if tentative:
-            return self.starting_X[self.accepted + self.tentative.tolist()]
+            return self.starting_X[self.accepted + list(self.tentative)]
         else:
             return self.starting_X[self.accepted]
 


### PR DESCRIPTION
What does this PR do?
=====================
Currently, if tentative is set to True, it raises an error because self.tentative can be a list, and not an array. Thus, to_list() does not work. This changes from to_list to list(), thus keeping the same behavior but fixing issues when self.tentative is already a list.

