### PR TITLE
Handle missing values in histgradboost trees

### DIFF
--- a/.github/workflows/branch-push.yml
+++ b/.github/workflows/branch-push.yml
@@ -19,7 +19,7 @@ jobs:
 #        run: python -m flake8 src
   test:
     name: Run Tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         python: [3.6, 3.7, 3.8]

--- a/src/BorutaShap.py
+++ b/src/BorutaShap.py
@@ -271,7 +271,7 @@ class BorutaShap:
         X_missing = self.X.isnull().any().any()
         Y_missing = self.missing_values_y()
 
-        models_to_check = ('xgb', 'catboost', 'lgbm', 'lightgbm')
+        models_to_check = ('xgb', 'catboost', 'lgbm', 'lightgbm', 'hist_gradient_boosting')
 
         model_name = str(type(self.model)).lower()
         if X_missing or Y_missing:

--- a/src/run_tests.py
+++ b/src/run_tests.py
@@ -5,7 +5,11 @@ from sklearn.tree import DecisionTreeClassifier, DecisionTreeRegressor
 from sklearn.ensemble import RandomForestClassifier, RandomForestRegressor
 from lightgbm import LGBMClassifier, LGBMRegressor
 
-
+# in sklearn.__version__ < 1.0, HistGradientBoostingClassifier is an experimental feature & is not fully supprted by shap
+from sklearn import __version__ as sklearn_version
+from distutils.version import StrictVersion
+if StrictVersion(sklearn_version) >= StrictVersion("1.0.0"):
+    from sklearn.ensemble import HistGradientBoostingRegressor ,HistGradientBoostingClassifier
 
 def Test_Models(data_type, models):
 
@@ -41,6 +45,9 @@ if __name__ == "__main__":
                        'xgboost-regressor':XGBRegressor(),'lightgbm-regressor':LGBMRegressor(),
                        'catboost-regressor':CatBoostRegressor()}
 
+    if StrictVersion(sklearn_version) >= StrictVersion("1.0.0"):
+        tree_classifiers['histgradientboosting-classifier'] = HistGradientBoostingClassifier()
+        tree_regressors['histgradientboosting-regressor'] = HistGradientBoostingRegressor()
     
     Test_Models('regression', tree_regressors)
     Test_Models('classification', tree_classifiers)

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ skipsdist = true
 
 [testenv]
 
-deps = sklearn
+deps = scikit-learn
        xgboost
        catboost
        lightgbm

--- a/tox.ini
+++ b/tox.ini
@@ -5,14 +5,14 @@ skipsdist = true
 [testenv]
 
 deps = sklearn
-       xgboost<=1.0.0
+       xgboost
        catboost
        lightgbm
        tqdm
        statsmodels
        numpy
        pandas
-       shap<=0.34.0
+       shap
        scipy
        seaborn    
        pytest 


### PR DESCRIPTION
What does this PR do?
=====================
Should address https://github.com/Ekeany/Boruta-Shap/issues/122

References
==========

Testing performed
=================
also fixed the actions workflow so that the tests run and can pass accounting for the HistogramGradientBoostingRegressor and HistogramGradientBoostingClassifier. I have also tested the changes against the code from the issue to verify that it works.

Known issues
============
HistogramGradientBoosting trees are not available in Python 3.6 so I had to include logic not to test them in that Python version.