### PR TITLE
BUG: Replace deprecated SciPy and NumPy functions (#130)

### DIFF
--- a/src/BorutaShap.py
+++ b/src/BorutaShap.py
@@ -6,7 +6,7 @@ from sklearn.preprocessing import MinMaxScaler
 from sklearn.cluster import KMeans
 from sklearn.inspection import permutation_importance
 from scipy.sparse import issparse
-from scipy.stats import binom_test, ks_2samp
+from scipy.stats import binomtest, ks_2samp
 import matplotlib.pyplot as plt
 from tqdm.auto import tqdm
 import random
@@ -527,8 +527,8 @@ class BorutaShap:
 
         """
 
-        padded_history_shadow  = np.full((self.ncols), np.NaN)
-        padded_history_x = np.full((self.ncols), np.NaN)
+        padded_history_shadow  = np.full((self.ncols), np.nan)
+        padded_history_x = np.full((self.ncols), np.nan)
 
         for (index, col) in enumerate(self.columns):
             map_index = self.order[col]
@@ -882,7 +882,7 @@ class BorutaShap:
         This is an exact, two-sided test of the null hypothesis
         that the probability of success in a Bernoulli experiment is p
         """
-        return [binom_test(x, n=n, p=p, alternative=alternative) for x in array]
+        return [binomtest(x, n=n, p=p, alternative=alternative).pvalue for x in array.astype(int)]
 
 
     @staticmethod


### PR DESCRIPTION
What does this PR do?
=====================
- Replaced `scipy.stats.binom_test` (removed in SciPy 1.12.0) with `scipy.stats.binomtest`, as suggested by @vimalcirrus in #130.
- Replaced `np.NaN` (deprecated in NumPy 2.0) with `np.nan` to ensure compatibility with future versions.

This update prevents compatibility issues with newer versions of SciPy and NumPy.

References
==========
#130 
https://stackoverflow.com/questions/78090426/cannot-import-name-binom-test-from-scipy-stats-error-when-using-borutashap

@Ekeany 
